### PR TITLE
fix: Add missing trailing slashes to filtered data model URL patterns…

### DIFF
--- a/backend/aimodel/urls.py
+++ b/backend/aimodel/urls.py
@@ -3,9 +3,9 @@ from .views import *
 
 urlpatterns = [
     path('get_all_simplify_data_models/', get_all_simplify_data_models, name='get_all_simplify_data_models'),
-    path('get_filtered_simplify_data_models', FilteredModelListView.as_view(), name = "get_filtered_simplify_data_models"),
+    path('get_filtered_simplify_data_models/', FilteredModelListView.as_view(), name = "get_filtered_simplify_data_models"),
     path('get_all_full_data_models/', get_all_full_data_models, name='get_all_full_data_models'),
-    path('get_filtered_full_data_models', FilteredFullModelListView.as_view(), name = "get_filtered_full_data_models"),
+    path('get_filtered_full_data_models/', FilteredFullModelListView.as_view(), name = "get_filtered_full_data_models"),
     path('get_all_tasks/', get_all_tasks, name = "get_all_tasks"),
     path('get_all_precisions/', get_all_precisions, name = "get_all_precisions"),
     


### PR DESCRIPTION
This pull request includes a minor update to the `backend/aimodel/urls.py` file to standardize URL patterns by ensuring all paths end with a trailing slash.

* [`backend/aimodel/urls.py`](diffhunk://#diff-705c598d7744a65f5be3f00c91644364168cedb8bbf4752fe3fadaba02b8a440L6-R8): Added trailing slashes to the `get_filtered_simplify_data_models` and `get_filtered_full_data_models` URL patterns for consistency with other paths.… for consistency